### PR TITLE
Fix incorrect plugin repository name

### DIFF
--- a/plugins/auto-scaling/index.md
+++ b/plugins/auto-scaling/index.md
@@ -35,7 +35,7 @@ bluemix plugin repo-add bluemix-plugin-repo https://plugins.ng.bluemix.net
 ```
 2. To install the {{site.data.keyword.autoscaling}} CLI plugin, run the following command:
 ```
-bluemix plugin install auto-scaling -r bluemix-plugin-repo
+bluemix plugin install auto-scaling -r Bluemix
 ```
 
 ## Attaching an auto-scaling policy


### PR DESCRIPTION
See https://stackoverflow.com/questions/44667260/bluemix-plugin-repo-does-not-exist-as-an-available-plug-in-repo-check-the-nam/44667261#44667261