### PR TITLE
Role corrections in 'Searching for a User' section

### DIFF
--- a/plugins/bluemix_admin/index.md
+++ b/plugins/bluemix_admin/index.md
@@ -149,7 +149,7 @@ cf ba search-users -name=<user_name_value> -permission=<permission_value> -organ
 <dt class="pt dlterm">&lt;organization_value&gt;</dt>
 <dd class="pd">The organization name that the user belongs to. You cannot use this parameter with the permission parameter in the same query.</dd>
 <dt class="pt dlterm">&lt;role_value&gt;</dt>
-<dd class="pd">The organization role assigned to the user. For example, auditor, manager, or billing_manager. You must specify the organization with this parameter. For more information about roles, see [User roles](/docs/admin/users_roles.html#userrolesinfo).</dd>
+<dd class="pd">The organization role assigned to the user. For example, user_roles, auditors, managers, or billing_managers. You must specify the organization with this parameter.</dd>
 
 </dl>
 


### PR DESCRIPTION
The roles listed in "Searching for a User" were not correct.  Also deleting a reference to a doc page (link) that no longer exists.