### PR TITLE
Changed users-delete to user-delete in docs

### DIFF
--- a/reference/bluemix_cli/bx_cli.md
+++ b/reference/bluemix_cli/bx_cli.md
@@ -115,7 +115,7 @@ The commands for managing {{site.data.keyword.BluSoftlayer_notm}} infrastructure
  <td>[bluemix account list](bx_cli.html#bluemix_account_list)</td>
  <td>[bluemix account org-account](bx_cli.html#bluemix_account_org_account)</td>
  <td>[bluemix account users](bx_cli.html#bluemix_account_users)</td>
- <td>[bluemix account users-delete](bx_cli.html#bluemix_account_users_delete)</td>
+ <td>[bluemix account user-delete](bx_cli.html#bluemix_account_user_delete)</td>
  <td>[bluemix account user-invite](bx_cli.html#bluemix_account_user_invite)</td>
  </tr>
  <tr>


### PR DESCRIPTION
Docs currently have users-delete, however that isn't an option in the CLI. Changed users-delete to user-delete and fixed the link so that it will link to the correct command later in the documentation. 