### PR TITLE
Update download_cli.md

### DIFF
--- a/reference/ibmcloud/download_cli.md
+++ b/reference/ibmcloud/download_cli.md
@@ -151,8 +151,6 @@ The following sections provide details on how to uninstall the stand-alone {{sit
 
 ### Uninstalling on Linux/macOS
 
-#### Prior to version `0.9.0`
-
 1. Open a terminal, and run the following commands:
   * `rm -rf /usr/local/ibmcloud`
   * `rm -f /usr/local/bin/ibmcloud`
@@ -160,13 +158,6 @@ The following sections provide details on how to uninstall the stand-alone {{sit
   * `rm -f /usr/local/bin/bx`
   * `rm -f /usr/local/bin/ibmcloud-analytics`
 2. Clean up the autocompletion scripts, if you've configured them. For more details, see [Enable CLI Autocompletion](enable_cli_autocompletion.html).
-
-#### Version `0.9.0` and later
-
-1. Open a terminal, and run the following command:
-  * `/usr/local/ibmcloud/uninstall`
-2. Clean up the autocompletion scripts, if you've configured them. For more details, see [Enable CLI Autocompletion](enable_cli_autocompletion.html).
-
 
 ## Other links to further explore {{site.data.keyword.Bluemix_notm}} CLI
 


### PR DESCRIPTION
There is no `/usr/local/ibmcloud/uninstall` command.

```shell
~/ > /usr/local/ibmcloud/uninstall
zsh: no such file or directory: /usr/local/ibmcloud/uninstall
~/> cd /usr/local/ibmcloud/    
/usr/local/ibmcloud > ls -la
total 16K
drwxr-xr-x  4 root 4.0K Sep 26 15:46 ./
drwxr-xr-x 12 root 4.0K Oct  3 11:29 ../
drwxr-xr-x  2 root 4.0K Sep 26 15:46 autocomplete/
drwxr-xr-x  3 root 4.0K Sep 26 15:46 bin/
/usr/local/ibmcloud > find . | grep uninstall
/usr/local/ibmcloud > ls                     
autocomplete/  bin/
/usr/local/ibmcloud > cd bin
/usr/local/ibmcloud/bin > ls
LICENSE*  NOTICE*  bluemix@  bx@  cfcli/  ibmcloud*  ibmcloud-analytics*
/usr/local/ibmcloud/bin > find .
.
./ibmcloud
./bluemix
./NOTICE
./LICENSE
./bx
./cfcli
./cfcli/cf
./ibmcloud-analytics
```